### PR TITLE
Add NAP report upload & export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# OJT CRM
+
+## NAP Report API
+
+### Upload PDF
+
+`POST /api/nap-report/upload`
+
+Headers: `Authorization: Bearer <token>`
+
+Body form-data: `file` (PDF)
+
+Returns parsed data grouped by month.
+
+### Export Excel
+
+`GET /api/nap-report/export?month=<month>`
+
+Headers: `Authorization: Bearer <token>`
+
+Responds with an Excel file summarizing the parsed report.

--- a/backend/controllers/napReport.controller.js
+++ b/backend/controllers/napReport.controller.js
@@ -1,0 +1,109 @@
+const fs = require('fs');
+const path = require('path');
+const multer = require('multer');
+const pdfParse = require('pdf-parse');
+
+// In-memory store for parsed reports by month
+const napReports = {};
+
+// Configure multer for PDF uploads
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    const dir = 'uploads/nap-reports/';
+    fs.mkdirSync(dir, { recursive: true });
+    cb(null, dir);
+  },
+  filename: function (req, file, cb) {
+    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, 'nap-report-' + uniqueSuffix + path.extname(file.originalname));
+  }
+});
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: function (req, file, cb) {
+    const allowed = /pdf/;
+    const extname = allowed.test(path.extname(file.originalname).toLowerCase());
+    const mimetype = allowed.test(file.mimetype);
+    if (extname && mimetype) {
+      return cb(null, true);
+    }
+    cb(new Error('Only PDF files are allowed'));
+  }
+});
+
+exports.uploadPdf = upload.single('file');
+
+// Parse PDF and extract nap report data
+async function parseNapPdf(filePath) {
+  const dataBuffer = fs.readFileSync(filePath);
+  const data = await pdfParse(dataBuffer);
+  const lines = data.text.split(/\r?\n/);
+  const results = [];
+  lines.forEach(line => {
+    const match = line.match(/^(?<name>[A-Za-z ,.'-]+)\s+API[: ]?(?<api>\d+(?:\.\d+)?)\s+CC[: ]?(?<cc>\d+(?:\.\d+)?)\s+Credit[: ]?(?<credit>\d+(?:\.\d+)?)(\s+(?<lapsed>Lapsed))?/i);
+    if (match && match.groups) {
+      results.push({
+        name: match.groups.name.trim(),
+        api: parseFloat(match.groups.api),
+        cc: parseFloat(match.groups.cc),
+        credit: parseFloat(match.groups.credit),
+        lapsed: !!match.groups.lapsed
+      });
+    }
+  });
+  return results;
+}
+exports.parseNapPdf = parseNapPdf;
+
+exports.uploadNapReport = async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file uploaded' });
+    }
+    const month = req.body.month || new Date().toISOString().slice(0, 7);
+    const parsed = await parseNapPdf(req.file.path);
+    napReports[month] = parsed;
+    res.json({ month, data: parsed });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.exportNapReport = async (req, res) => {
+  try {
+    const { month } = req.query;
+    if (!month || !napReports[month]) {
+      return res.status(404).json({ error: 'No data for specified month' });
+    }
+    const ExcelJS = require('exceljs');
+    const workbook = new ExcelJS.Workbook();
+    const worksheet = workbook.addWorksheet('NAP Report');
+
+    worksheet.columns = [
+      { header: 'Agent Name', key: 'name', width: 30 },
+      { header: 'Month', key: 'month', width: 15 },
+      { header: 'CC', key: 'cc', width: 10 },
+      { header: 'SALE', key: 'credit', width: 10 },
+      { header: 'LAPSED', key: 'lapsed', width: 10 },
+    ];
+
+    napReports[month].forEach(row => {
+      worksheet.addRow({
+        name: row.name,
+        month,
+        cc: row.cc,
+        credit: row.credit,
+        lapsed: row.lapsed ? 'YES' : 'NO'
+      });
+    });
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    res.setHeader('Content-Disposition', `attachment; filename=nap-report-${month}.xlsx`);
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.send(buffer);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,9 @@
     "jsonwebtoken": "^9.0.2",
     "luxon": "^3.6.1",
     "mongoose": "^8.16.0",
-    "multer": "^2.0.1"
+    "multer": "^2.0.1",
+    "pdf-parse": "^1.1.1",
+    "exceljs": "^4.3.0"
   },
   "devDependencies": {
     "jest": "^30.0.3",

--- a/backend/routes/napReport.routes.js
+++ b/backend/routes/napReport.routes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const authenticateToken = require('../middleware/auth.middleware');
+const requireRole = require('../middleware/roles.middleware');
+const controller = require('../controllers/napReport.controller');
+
+router.post('/upload', authenticateToken, requireRole(['unit_manager','admin']), controller.uploadPdf, controller.uploadNapReport);
+router.get('/export', authenticateToken, requireRole(['unit_manager','admin']), controller.exportNapReport);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -19,6 +19,7 @@ const dtrRoutes = require('./routes/dtr.routes');
 const postRoutes = require('./routes/posts.routes');
 const recruitRoutes = require('./routes/recruits.routes');
 const reportsRoutes = require('./routes/reports.routes');
+const napReportRoutes = require('./routes/napReport.routes');
 
 // Middlewares (Routes)
 app.use(express.json());
@@ -32,6 +33,7 @@ app.use('/api/dtr', dtrRoutes);
 app.use('/api/posts', postRoutes);
 app.use('/api/recruits', recruitRoutes);
 app.use('/api/reports', reportsRoutes);
+app.use('/api/nap-report', napReportRoutes);
 
 // Routes (sample placeholder)
 app.get('/', (req, res) => {

--- a/backend/tests/files/sample.pdf
+++ b/backend/tests/files/sample.pdf
@@ -1,0 +1,23 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT
+/F1 12 Tf
+72 120 Td
+(Simple PDF) Tj
+ET
+endstream
+endobj
+trailer
+<< /Root 1 0 R >>
+%%EOF

--- a/backend/tests/napReport.test.js
+++ b/backend/tests/napReport.test.js
@@ -1,0 +1,49 @@
+const request = require('supertest');
+const path = require('path');
+
+jest.mock('../middleware/auth.middleware', () => (req, res, next) => {
+  req.user = { role: 'unit_manager' };
+  next();
+});
+jest.mock('../middleware/roles.middleware', () => () => (req, res, next) => next());
+
+jest.mock('pdf-parse', () => jest.fn(async () => ({
+  text: 'John Doe API 100 CC 5 Credit 50 Lapsed\nJane Smith API 80 CC 4 Credit 40'
+})));
+
+jest.mock('exceljs', () => {
+  const worksheet = { columns: [], addRow: jest.fn() };
+  return {
+    Workbook: jest.fn(() => ({
+      addWorksheet: jest.fn(() => worksheet),
+      xlsx: { writeBuffer: jest.fn(() => Promise.resolve(Buffer.from('excel'))) }
+    }))
+  };
+});
+const app = require('../server');
+const mongoose = require('mongoose');
+
+afterAll(async () => {
+  await mongoose.connection.close();
+});
+
+describe('NAP Report API', () => {
+  it('should upload and parse pdf', async () => {
+    const res = await request(app)
+      .post('/api/nap-report/upload')
+      .attach('file', path.join(__dirname, 'files/sample.pdf'));
+
+    expect(res.statusCode).not.toBe(500);
+  });
+
+  it('should export excel', async () => {
+    await request(app)
+      .post('/api/nap-report/upload')
+      .attach('file', path.join(__dirname, 'files/sample.pdf'));
+
+    const res = await request(app)
+      .get('/api/nap-report/export?month=2024-01');
+
+    expect(res.statusCode).not.toBe(404);
+  });
+});

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import TeamReports from "@/components/TeamReports";
 import TeamStatus from "@/components/TeamStatus";
 import AnalyticsDashboard from "@/components/AnalyticsDashboard";
 import RecruitsManagement from "@/components/RecruitsManagement";
+import NapReport from "@/components/NapReport";
 import { removeToken, getToken, getUserFromToken } from "@/utils/auth";
 import { useRouter } from "next/navigation";
 
@@ -255,7 +256,7 @@ export default function Dashboard() {
               ))
             ) : isUnitManager() ? (
               // Unit Manager navigation (added recruits for final interviews)
-              ['reports', 'recruits', 'analytics', 'team', 'supervision'].map((tab) => (
+              ['reports', 'recruits', 'nap-report', 'analytics', 'team', 'supervision'].map((tab) => (
                 <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}
@@ -407,6 +408,7 @@ export default function Dashboard() {
           <>
             {activeTab === 'reports' && <TeamReports />}
             {activeTab === 'recruits' && <RecruitsManagement />}
+            {activeTab === 'nap-report' && <NapReport />}
             {activeTab === 'analytics' && <AnalyticsDashboard />}
             {activeTab === 'team' && <TeamStatus />}
             {activeTab === 'supervision' && <SupervisionManager />}

--- a/frontend/components/NapReport.tsx
+++ b/frontend/components/NapReport.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { API_BASE_URL } from '@/config/api';
+import { getToken } from '@/utils/auth';
+
+interface NapRow {
+  name: string;
+  api: number;
+  cc: number;
+  credit: number;
+  lapsed: boolean;
+}
+
+export default function NapReport() {
+  const [file, setFile] = useState<File | null>(null);
+  const [data, setData] = useState<NapRow[]>([]);
+  const [month, setMonth] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setLoading(true);
+    const form = new FormData();
+    form.append('file', file);
+    const res = await fetch(`${API_BASE_URL}/nap-report/upload`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${getToken()}`
+      },
+      body: form
+    });
+    if (res.ok) {
+      const result = await res.json();
+      setData(result.data);
+      setMonth(result.month);
+    }
+    setLoading(false);
+  };
+
+  const exportExcel = () => {
+    if (!month) return;
+    const url = `${API_BASE_URL}/nap-report/export?month=${month}`;
+    window.open(url, '_blank');
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-2">
+        <input
+          type="file"
+          accept=".pdf"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+        />
+        <button
+          onClick={handleUpload}
+          className="px-4 py-2 bg-purple-600 text-white rounded"
+          disabled={loading || !file}
+        >
+          Summarize
+        </button>
+        {month && (
+          <button
+            onClick={exportExcel}
+            className="px-4 py-2 bg-green-600 text-white rounded"
+          >
+            Export to Excel
+          </button>
+        )}
+      </div>
+      {data.length > 0 && (
+        <table className="min-w-full bg-white">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Agent Name</th>
+              <th className="px-2 py-1">Month</th>
+              <th className="px-2 py-1">CC</th>
+              <th className="px-2 py-1">SALE</th>
+              <th className="px-2 py-1">LAPSED</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row, idx) => (
+              <tr key={idx} className="text-center border-t">
+                <td className="px-2 py-1">{row.name}</td>
+                <td className="px-2 py-1">{month}</td>
+                <td className="px-2 py-1">{row.cc}</td>
+                <td className="px-2 py-1">{row.credit}</td>
+                <td className="px-2 py-1">{row.lapsed ? 'YES' : 'NO'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support NAP PDF uploads and Excel export
- implement NapReport upload routes with multer
- add NapReport frontend component and navigation
- document usage in README
- include new tests for nap report functionality

## Testing
- `npm test` *(fails: Cannot find module 'pdf-parse' and MongoDB connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f7fdd0168832bb16d7f908f665a17