### PR TITLE
feat(frontend): centralize theme colors

### DIFF
--- a/frontend/components/HoursManager.tsx
+++ b/frontend/components/HoursManager.tsx
@@ -204,8 +204,32 @@ export default function HoursManager() {
                   />
                   <defs>
                     <linearGradient id="progressGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" className="stop-color-current" style={{ stopColor: getProgressColor().includes('green') ? '#10b981' : getProgressColor().includes('blue') ? '#3b82f6' : getProgressColor().includes('yellow') ? '#f59e0b' : '#ef4444' }} />
-                      <stop offset="100%" className="stop-color-current" style={{ stopColor: getProgressColor().includes('green') ? '#059669' : getProgressColor().includes('blue') ? '#8b5cf6' : getProgressColor().includes('yellow') ? '#ea580c' : '#ec4899' }} />
+                      <stop
+                        offset="0%"
+                        className="stop-color-current"
+                        style={{
+                          stopColor: getProgressColor().includes('green')
+                            ? '#10b981'
+                            : getProgressColor().includes('blue')
+                              ? 'rgb(var(--color-secondary))'
+                              : getProgressColor().includes('yellow')
+                                ? '#f59e0b'
+                                : '#ef4444',
+                        }}
+                      />
+                      <stop
+                        offset="100%"
+                        className="stop-color-current"
+                        style={{
+                          stopColor: getProgressColor().includes('green')
+                            ? '#059669'
+                            : getProgressColor().includes('blue')
+                              ? 'rgb(var(--color-accent))'
+                              : getProgressColor().includes('yellow')
+                                ? '#ea580c'
+                                : '#ec4899',
+                        }}
+                      />
                     </linearGradient>
                   </defs>
                 </svg>

--- a/frontend/components/RecruitsManagement.tsx
+++ b/frontend/components/RecruitsManagement.tsx
@@ -1513,21 +1513,43 @@ export default function RecruitsManagement() {
                   type="button"
                   aria-pressed={scheduleData.createZoomMeeting}
                   onClick={() => setScheduleData({ ...scheduleData, createZoomMeeting: !scheduleData.createZoomMeeting })}
-                  className={`w-full flex items-center justify-center px-4 py-2 rounded-lg font-semibold text-sm transition-all focus:outline-none focus:ring-2 focus:ring-blue-400 border border-blue-500/40 shadow-md
+                  className={`w-full flex items-center justify-center px-4 py-2 rounded-lg font-semibold text-sm transition-all focus:outline-none focus:ring-2 focus:ring-secondary border border-primary/40 shadow-md
                     ${scheduleData.createZoomMeeting
-                      ? 'bg-blue-600 text-white ring-2 ring-blue-400 animate-pulse shadow-blue-500/40'
-                      : 'bg-white/10 text-blue-400 hover:bg-blue-500/20'}
+                      ? 'bg-primary text-white ring-2 ring-secondary animate-pulse shadow-[0_0_8px_2px_rgb(var(--color-primary))]'
+                      : 'bg-white/10 text-secondary hover:bg-secondary/20'}
                   `}
-                  style={{ boxShadow: scheduleData.createZoomMeeting ? '0 0 8px 2px #2563eb' : undefined }}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20" className="mr-2"><rect width="32" height="32" rx="8" fill="#2563eb"/><path d="M23.5 13.5l3.5-2.5v9l-3.5-2.5v-4zm-1.5-2c.828 0 1.5.672 1.5 1.5v8c0 .828-.672 1.5-1.5 1.5h-12c-.828 0-1.5-.672-1.5-1.5v-8c0-.828.672-1.5 1.5-1.5h12z" fill="#fff"/></svg>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 32 32"
+                    width="20"
+                    height="20"
+                    className="mr-2"
+                  >
+                    <rect width="32" height="32" rx="8" className="fill-primary" />
+                    <path
+                      d="M23.5 13.5l3.5-2.5v9l-3.5-2.5v-4zm-1.5-2c.828 0 1.5.672 1.5 1.5v8c0 .828-.672 1.5-1.5 1.5h-12c-.828 0-1.5-.672-1.5-1.5v-8c0-.828.672-1.5 1.5-1.5h12z"
+                      className="fill-white"
+                    />
+                  </svg>
                   {scheduleData.createZoomMeeting ? 'Zoom Meeting Enabled' : 'Enable Zoom Meeting'}
                 </button>
               </div>
               {scheduleData.createZoomMeeting && (
-                <div className="text-sm text-blue-300 bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 mt-2">
+                <div className="text-sm text-accent bg-secondary/10 border border-secondary/20 rounded-lg p-3 mt-2">
                   <div className="flex items-center space-x-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" className="text-blue-400"><circle cx="12" cy="12" r="10" fill="#2563eb"/><text x="12" y="16" textAnchor="middle" fontSize="12" fill="#fff">i</text></svg>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      width="18"
+                      height="18"
+                      className="text-secondary"
+                    >
+                      <circle cx="12" cy="12" r="10" className="fill-primary" />
+                      <text x="12" y="16" textAnchor="middle" fontSize="12" className="fill-white">
+                        i
+                      </text>
+                    </svg>
                     <span>A Zoom meeting will be automatically created and the applicant will receive an email invitation with meeting details and calendar invite.</span>
                   </div>
                 </div>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#2563eb',
+        secondary: '#3b82f6',
+        accent: '#8b5cf6',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind config with `primary`, `secondary`, and `accent` blue shades
- replace hard-coded blue hex values in HoursManager and RecruitsManagement with new tokens

## Testing
- `npm install` (fails: ENOTEMPTY: directory not empty, rename '/workspace/ojt_crm/frontend/node_modules/eslint-import-resolver-node' -> '/workspace/ojt_crm/frontend/node_modules/.eslint-import-resolver-node-QRrndDNW')
- `npm run build` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68995e5bbb28832bad08f6d38cc98e3b