### PR TITLE
refactor: update UI to blue palette

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -127,9 +127,9 @@ export default function Dashboard() {
 
   return (
     <AuthGuard>
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden">
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden">
       {/* Background gradient overlays */}
-      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10"></div>
+      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-blue-500/10 to-cyan-500/10"></div>
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.1),transparent_50%)]"></div>
       
       {/* Header */}
@@ -138,7 +138,7 @@ export default function Dashboard() {
           <div className="flex justify-between items-center h-14 sm:h-16">
             <div className="flex items-center space-x-2 sm:space-x-4">
               <div className="flex items-center space-x-2 sm:space-x-3">
-                <div className="w-7 h-7 sm:w-8 sm:h-8 bg-gradient-to-br from-purple-400 to-pink-400 rounded-lg flex items-center justify-center">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-lg flex items-center justify-center">
                   <span className="text-white font-bold text-xs sm:text-sm">C</span>
                 </div>
                 <h1 className="text-lg sm:text-xl font-bold text-white">CRM Dashboard</h1>
@@ -193,7 +193,7 @@ export default function Dashboard() {
                           <p className="text-xs text-gray-400 truncate">
                             {user ? user.email : ''}
                           </p>
-                          <p className="text-xs text-purple-400">
+                          <p className="text-xs text-blue-400">
                             {user ? formatRole(user.role) : ''}
                           </p>
                         </div>
@@ -250,7 +250,7 @@ export default function Dashboard() {
                   onClick={() => setActiveTab(tab)}
                   className={`py-3 sm:py-4 px-1 border-b-2 font-medium text-xs sm:text-sm capitalize transition-colors whitespace-nowrap ${
                     activeTab === tab
-                      ? 'border-purple-400 text-purple-400'
+                      ? 'border-blue-400 text-blue-400'
                       : 'border-transparent text-gray-400 hover:text-white hover:border-white/20'
                   }`}
                 >
@@ -265,7 +265,7 @@ export default function Dashboard() {
                   onClick={() => setActiveTab(tab)}
                   className={`py-3 sm:py-4 px-1 border-b-2 font-medium text-xs sm:text-sm capitalize transition-colors whitespace-nowrap ${
                     activeTab === tab
-                      ? 'border-purple-400 text-purple-400'
+                      ? 'border-blue-400 text-blue-400'
                       : 'border-transparent text-gray-400 hover:text-white hover:border-white/20'
                   }`}
                 >
@@ -282,7 +282,7 @@ export default function Dashboard() {
                       onClick={() => setActiveTab(tab)}
                       className={`py-3 sm:py-4 px-1 border-b-2 font-medium text-xs sm:text-sm capitalize transition-colors whitespace-nowrap ${
                         activeTab === tab
-                          ? 'border-purple-400 text-purple-400'
+                          ? 'border-blue-400 text-blue-400'
                           : 'border-transparent text-gray-400 hover:text-white hover:border-white/20'
                       }`}
                     >
@@ -295,7 +295,7 @@ export default function Dashboard() {
                       onClick={() => setActiveTab(tab)}
                       className={`py-3 sm:py-4 px-1 border-b-2 font-medium text-xs sm:text-sm capitalize transition-colors whitespace-nowrap ${
                         activeTab === tab
-                          ? 'border-purple-400 text-purple-400'
+                          ? 'border-blue-400 text-blue-400'
                           : 'border-transparent text-gray-400 hover:text-white hover:border-white/20'
                       }`}
                     >
@@ -309,7 +309,7 @@ export default function Dashboard() {
                     onClick={() => setActiveTab(tab)}
                     className={`py-3 sm:py-4 px-1 border-b-2 font-medium text-xs sm:text-sm capitalize transition-colors whitespace-nowrap ${
                       activeTab === tab
-                        ? 'border-purple-400 text-purple-400'
+                        ? 'border-blue-400 text-blue-400'
                         : 'border-transparent text-gray-400 hover:text-white hover:border-white/20'
                     }`}
                   >
@@ -330,7 +330,7 @@ export default function Dashboard() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
               {stats.map((stat, index) => (
                 <div key={index} className="group relative">
-                  <div className="absolute inset-0 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+                  <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
                   <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-4 sm:p-6 hover:bg-white/15 transition-all duration-300">
                     <div className="flex items-center justify-between mb-3 sm:mb-4">
                       <div className="flex-1 min-w-0">
@@ -353,12 +353,12 @@ export default function Dashboard() {
               {/* Chart Area */}
               <div className="lg:col-span-2">
                 <div className="group relative">
-                  <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-purple-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+                  <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
                   <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-4 sm:p-6">
                     <h3 className="text-base sm:text-lg font-semibold text-white mb-3 sm:mb-4">Analytics Overview</h3>
-                    <div className="h-48 sm:h-64 bg-gradient-to-br from-purple-500/20 to-pink-500/20 rounded-lg flex items-center justify-center">
+                    <div className="h-48 sm:h-64 bg-gradient-to-br from-blue-500/20 to-cyan-500/20 rounded-lg flex items-center justify-center">
                       <div className="text-center">
-                        <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full mx-auto mb-3 sm:mb-4 flex items-center justify-center">
+                        <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full mx-auto mb-3 sm:mb-4 flex items-center justify-center">
                           <svg className="w-6 h-6 sm:w-8 sm:h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                           </svg>
@@ -378,7 +378,7 @@ export default function Dashboard() {
                   <div className="space-y-3 sm:space-y-4">
                     {recentActivities.map((activity, index) => (
                       <div key={index} className="flex items-start space-x-3 p-2 sm:p-3 rounded-lg bg-white/5 hover:bg-white/10 transition-colors">
-                        <div className="w-2 h-2 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full mt-2 flex-shrink-0"></div>
+                        <div className="w-2 h-2 bg-gradient-to-r from-blue-400 to-cyan-400 rounded-full mt-2 flex-shrink-0"></div>
                         <div className="flex-1 min-w-0">
                           <p className="text-xs sm:text-sm text-white font-medium truncate">{activity.action}</p>
                           <p className="text-xs text-gray-400 truncate">by {activity.user}</p>
@@ -394,15 +394,15 @@ export default function Dashboard() {
             {/* Quick Actions */}
             <div className="mt-6 sm:mt-8">
               <div className="group relative">
-                <div className="absolute inset-0 bg-gradient-to-r from-violet-600/20 to-purple-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+                <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
                 <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-4 sm:p-6">
                   <h3 className="text-base sm:text-lg font-semibold text-white mb-3 sm:mb-4">Quick Actions</h3>
                   <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
                     {[
-                      { title: 'Add User', icon: '👤', color: 'from-blue-500 to-purple-500' },
+                      { title: 'Add User', icon: '👤', color: 'from-blue-500 to-cyan-500' },
                       { title: 'Create Post', icon: '📝', color: 'from-emerald-500 to-cyan-500' },
                       { title: 'Review Recruits', icon: '🎯', color: 'from-orange-500 to-red-500' },
-                      { title: 'Generate Report', icon: '📊', color: 'from-pink-500 to-rose-500' },
+                      { title: 'Generate Report', icon: '📊', color: 'from-cyan-500 to-rose-500' },
                     ].map((action, index) => (
                       <button
                         key={index}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -32,12 +32,12 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: linear-gradient(to bottom, #8b5cf6, #ec4899);
+  background: linear-gradient(to bottom, #3b82f6, #0ea5e9);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(to bottom, #7c3aed, #db2777);
+  background: linear-gradient(to bottom, #2563eb, #0284c7);
 }
 
 /* Glassmorphism effect */
@@ -65,7 +65,7 @@ body {
 
 /* Gradient text */
 .gradient-text {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, #3b82f6 0%, #0ea5e9 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -94,7 +94,7 @@ body {
 /* Custom borders */
 .border-gradient {
   border: 1px solid;
-  border-image: linear-gradient(135deg, #667eea, #764ba2, #f093fb, #f5576c) 1;
+  border-image: linear-gradient(135deg, #3b82f6, #0ea5e9, #38bdf8, #2563eb) 1;
 }
 
 /* Loading spinner */
@@ -117,16 +117,13 @@ body {
   text-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
 }
 
+
 .glow {
-  box-shadow: 0 0 20px rgba(139, 92, 246, 0.3);
+  box-shadow: 0 0 20px rgba(59, 130, 246, 0.3);
 }
 
 .glow-lg {
-  box-shadow: 0 0 40px rgba(139, 92, 246, 0.4);
-}
-
-.glow-pink {
-  box-shadow: 0 0 20px rgba(236, 72, 153, 0.3);
+  box-shadow: 0 0 40px rgba(59, 130, 246, 0.4);
 }
 
 .glow-blue {

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -52,19 +52,19 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
       {/* Background gradient overlays */}
-      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10"></div>
+      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-blue-500/10 to-cyan-500/10"></div>
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.1),transparent_50%)]"></div>
       
       {/* Main Content */}
       <div className="relative z-10 w-full max-w-md mx-auto px-4 sm:px-6 lg:px-8">
         <div className="group relative">
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-2xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-2xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
           <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-2xl p-6 sm:p-8 hover:bg-white/15 transition-all duration-300">
             {/* Logo */}
             <div className="text-center mb-6">
-              <div className="w-16 h-16 bg-gradient-to-br from-purple-400 to-pink-400 rounded-xl mx-auto mb-4 flex items-center justify-center">
+              <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-xl mx-auto mb-4 flex items-center justify-center">
                 <span className="text-white font-bold text-2xl">C</span>
               </div>
               <h1 className="text-2xl font-bold text-white">Welcome Back</h1>
@@ -91,7 +91,7 @@ export default function Login() {
                   value={formData.email}
                   onChange={handleChange}
                   required
-                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                   placeholder="Enter your email"
                 />
               </div>
@@ -107,7 +107,7 @@ export default function Login() {
                   value={formData.password}
                   onChange={handleChange}
                   required
-                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                   placeholder="Enter your password"
                 />
               </div>
@@ -115,7 +115,7 @@ export default function Login() {
               <button
                 type="submit"
                 disabled={isLoading}
-                className="w-full py-3 px-4 bg-gradient-to-r from-purple-500 to-pink-500 text-white font-semibold rounded-lg hover:from-purple-600 hover:to-pink-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 transform hover:scale-105"
+                className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-cyan-500 text-white font-semibold rounded-lg hover:from-blue-600 hover:to-cyan-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 transform hover:scale-105"
               >
                 {isLoading ? 'Signing in...' : 'Sign In'}
               </button>
@@ -125,7 +125,7 @@ export default function Login() {
             <div className="mt-6 text-center">
               <p className="text-gray-400">
                 Don't have an account?{' '}
-                <Link href="/signup" className="text-purple-400 hover:text-purple-300 font-medium transition-colors">
+                <Link href="/signup" className="text-blue-400 hover:text-blue-300 font-medium transition-colors">
                   Create Account
                 </Link>
               </p>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -17,17 +17,17 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
       {/* Background gradient overlays */}
-      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10"></div>
+      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-blue-500/10 to-cyan-500/10"></div>
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.1),transparent_50%)]"></div>
       
       {/* Main Content */}
       <div className="relative z-10 text-center px-4 sm:px-6 lg:px-8">
         <div className="group relative">
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-2xl sm:rounded-3xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-2xl sm:rounded-3xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
           <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-2xl sm:rounded-3xl p-8 sm:p-12 hover:bg-white/15 transition-all duration-300">
-            <div className="w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-purple-400 to-pink-400 rounded-xl sm:rounded-2xl mx-auto mb-4 sm:mb-6 flex items-center justify-center">
+            <div className="w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-xl sm:rounded-2xl mx-auto mb-4 sm:mb-6 flex items-center justify-center">
               <span className="text-white font-bold text-2xl sm:text-3xl">TB</span>
             </div>
             <h1 className="text-3xl sm:text-4xl md:text-6xl font-bold text-white mb-3 sm:mb-4">
@@ -38,7 +38,7 @@ export default function Home() {
             </p>
             <button 
               onClick={handleLaunchDashboard}
-              className="inline-flex items-center px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-purple-500 to-pink-500 text-white font-semibold rounded-lg sm:rounded-xl hover:from-purple-600 hover:to-pink-600 transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl text-sm sm:text-base"
+              className="inline-flex items-center px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-blue-500 to-cyan-500 text-white font-semibold rounded-lg sm:rounded-xl hover:from-blue-600 hover:to-cyan-600 transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl text-sm sm:text-base"
             >
               <span className="mr-2">Launch Dashboard</span>
               <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -56,7 +56,7 @@ export default function Home() {
             { title: 'Performance Analytics', icon: '📊', desc: 'Team performance metrics and reporting' },
           ].map((feature, index) => (
             <div key={index} className="group relative">
-              <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-purple-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+                <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
               <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-4 sm:p-6 hover:bg-white/15 transition-all duration-300">
                 <div className="text-3xl sm:text-4xl mb-3 sm:mb-4">{feature.icon}</div>
                 <h3 className="text-base sm:text-lg font-semibold text-white mb-2">{feature.title}</h3>

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -73,19 +73,19 @@ export default function SignUp() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
       {/* Background gradient overlays */}
-      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10"></div>
+      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-blue-500/10 to-cyan-500/10"></div>
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.1),transparent_50%)]"></div>
       
       {/* Main Content */}
       <div className="relative z-10 w-full max-w-md mx-auto px-4 sm:px-6 lg:px-8">
         <div className="group relative">
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-2xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-2xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
           <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-2xl p-6 sm:p-8 hover:bg-white/15 transition-all duration-300">
             {/* Logo */}
             <div className="text-center mb-6">
-              <div className="w-16 h-16 bg-gradient-to-br from-purple-400 to-pink-400 rounded-xl mx-auto mb-4 flex items-center justify-center">
+              <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-xl mx-auto mb-4 flex items-center justify-center">
                 <span className="text-white font-bold text-2xl">C</span>
               </div>
               <h1 className="text-2xl font-bold text-white">Create Account</h1>
@@ -112,7 +112,7 @@ export default function SignUp() {
                   value={formData.name}
                   onChange={handleChange}
                   required
-                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                   placeholder="Enter your full name"
                 />
               </div>
@@ -128,7 +128,7 @@ export default function SignUp() {
                   value={formData.email}
                   onChange={handleChange}
                   required
-                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                   placeholder="Enter your email"
                 />
               </div>
@@ -207,7 +207,7 @@ export default function SignUp() {
                   value={formData.password}
                   onChange={handleChange}
                   required
-                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                   placeholder="Create a password"
                 />
               </div>
@@ -223,7 +223,7 @@ export default function SignUp() {
                   value={formData.confirmPassword}
                   onChange={handleChange}
                   required
-                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                   placeholder="Confirm your password"
                 />
               </div>
@@ -231,7 +231,7 @@ export default function SignUp() {
               <button
                 type="submit"
                 disabled={isLoading}
-                className="w-full py-3 px-4 bg-gradient-to-r from-purple-500 to-pink-500 text-white font-semibold rounded-lg hover:from-purple-600 hover:to-pink-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 transform hover:scale-105"
+                className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-cyan-500 text-white font-semibold rounded-lg hover:from-blue-600 hover:to-cyan-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 transform hover:scale-105"
               >
                 {isLoading ? 'Creating Account...' : 'Create Account'}
               </button>
@@ -241,7 +241,7 @@ export default function SignUp() {
             <div className="mt-6 text-center">
               <p className="text-gray-400">
                 Already have an account?{' '}
-                <Link href="/login" className="text-purple-400 hover:text-purple-300 font-medium transition-colors">
+                <Link href="/login" className="text-blue-400 hover:text-blue-300 font-medium transition-colors">
                   Sign In
                 </Link>
               </p>

--- a/frontend/components/AnalyticsDashboard.tsx
+++ b/frontend/components/AnalyticsDashboard.tsx
@@ -152,12 +152,12 @@ export default function AnalyticsDashboard() {
         {
           label: 'Team Productivity (%)',
           data: analyticsData.teamProductivity.map(item => item.productivity),
-          borderColor: 'rgb(139, 92, 246)', // purple-500
-          backgroundColor: 'rgba(139, 92, 246, 0.1)',
+          borderColor: 'rgb(59, 130, 246)', // blue-500
+          backgroundColor: 'rgba(59, 130, 246, 0.1)',
           fill: true,
           tension: 0.4,
-          pointBackgroundColor: 'rgb(139, 92, 246)',
-          pointBorderColor: 'rgb(139, 92, 246)',
+          pointBackgroundColor: 'rgb(59, 130, 246)',
+          pointBorderColor: 'rgb(59, 130, 246)',
           pointBorderWidth: 2,
           pointRadius: 5,
           pointHoverRadius: 7,
@@ -217,7 +217,7 @@ export default function AnalyticsDashboard() {
     }
 
     const colors = [
-      'rgba(139, 92, 246, 0.8)', // purple-500
+      'rgba(59, 130, 246, 0.8)', // blue-500
       'rgba(6, 182, 212, 0.8)',  // cyan-500
       'rgba(16, 185, 129, 0.8)', // green-500
       'rgba(245, 158, 11, 0.8)', // amber-500
@@ -253,8 +253,8 @@ export default function AnalyticsDashboard() {
         {
           label: 'Hours Worked',
           data: analyticsData.memberPerformance.map(item => item.hours),
-          backgroundColor: 'rgba(139, 92, 246, 0.8)', // purple-500
-          borderColor: 'rgb(139, 92, 246)',
+          backgroundColor: 'rgba(59, 130, 246, 0.8)', // blue-500
+          borderColor: 'rgb(59, 130, 246)',
           borderWidth: 2,
           borderRadius: 6,
           borderSkipped: false,
@@ -285,7 +285,7 @@ export default function AnalyticsDashboard() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="w-12 h-12 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full animate-spin flex items-center justify-center">
+        <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full animate-spin flex items-center justify-center">
           <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full"></div>
         </div>
       </div>
@@ -318,7 +318,7 @@ export default function AnalyticsDashboard() {
           <select 
             value={selectedPeriod} 
             onChange={(e) => setSelectedPeriod(e.target.value)}
-            className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+            className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="week">This Week</option>
             <option value="month">This Month</option>
@@ -396,8 +396,8 @@ export default function AnalyticsDashboard() {
                       : 0}%
                   </p>
                 </div>
-                <div className="w-10 h-10 bg-purple-500/20 rounded-lg flex items-center justify-center">
-                  <svg className="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 bg-blue-500/20 rounded-lg flex items-center justify-center">
+                  <svg className="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
                   </svg>
                 </div>

--- a/frontend/components/AuthGuard.tsx
+++ b/frontend/components/AuthGuard.tsx
@@ -31,12 +31,12 @@ export default function AuthGuard({ children }: AuthGuardProps) {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
-        <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10"></div>
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden flex items-center justify-center">
+        <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-blue-500/10 to-cyan-500/10"></div>
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.1),transparent_50%)]"></div>
         
         <div className="relative z-10 text-center">
-          <div className="w-16 h-16 bg-gradient-to-br from-purple-400 to-pink-400 rounded-xl mx-auto mb-4 flex items-center justify-center animate-spin">
+          <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-xl mx-auto mb-4 flex items-center justify-center animate-spin">
             <span className="text-white font-bold text-2xl">C</span>
           </div>
           <p className="text-white text-lg">Loading...</p>

--- a/frontend/components/DTRHistory.tsx
+++ b/frontend/components/DTRHistory.tsx
@@ -487,7 +487,7 @@ export default function DTRHistory() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="w-12 h-12 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full animate-spin flex items-center justify-center">
+        <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full animate-spin flex items-center justify-center">
           <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full"></div>
         </div>
       </div>
@@ -528,7 +528,7 @@ export default function DTRHistory() {
             placeholder="Search by accomplishment or date..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+            className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
         <div>
@@ -536,7 +536,7 @@ export default function DTRHistory() {
             type="date"
             value={dateFilter}
             onChange={(e) => setDateFilter(e.target.value)}
-            className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+            className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
       </div>
@@ -546,7 +546,7 @@ export default function DTRHistory() {
         <h3 className="text-xl font-semibold text-white mb-4">All DTR Entries</h3>
         {filteredEntries.length === 0 ? (
           <div className="text-center py-12">
-            <div className="w-16 h-16 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full mx-auto mb-4 flex items-center justify-center">
+            <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full mx-auto mb-4 flex items-center justify-center">
               <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
               </svg>
@@ -584,7 +584,7 @@ export default function DTRHistory() {
                     {/* Hours worked display */}
                     <div className="text-right">
                       {entry.hoursWorked > 0 && (
-                        <div className="text-purple-400 font-semibold">
+                        <div className="text-blue-400 font-semibold">
                           {entry.hoursWorked.toFixed(1)}h
                         </div>
                       )}
@@ -596,7 +596,7 @@ export default function DTRHistory() {
                     {/* Edit accomplishment button */}
                     <button
                       onClick={() => startEditingAccomplishment(entry)}
-                      className="px-3 py-1 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors text-sm flex items-center space-x-1"
+                      className="px-3 py-1 bg-blue-500/20 text-blue-400 rounded-lg hover:bg-blue-500/30 transition-colors text-sm flex items-center space-x-1"
                       title="Edit accomplishment"
                     >
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -651,7 +651,7 @@ export default function DTRHistory() {
                 value={editAccomplishment}
                 onChange={(e) => setEditAccomplishment(e.target.value)}
                 rows={6}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Describe what you accomplished during this work session..."
               />
             </div>
@@ -668,7 +668,7 @@ export default function DTRHistory() {
               </button>
               <button
                 onClick={handleUpdateAccomplishment}
-                className="px-6 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all"
+                className="px-6 py-2 bg-gradient-to-r from-blue-500 to-cyan-500 text-white rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all"
               >
                 Save Changes
               </button>
@@ -715,7 +715,7 @@ export default function DTRHistory() {
                   {['CSV', 'JSON'].map((format) => (
                     <button
                       key={format}
-                      className="px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg text-sm"
+                      className="px-4 py-2 bg-blue-500/20 text-blue-400 rounded-lg text-sm"
                     >
                       {format} Format
                     </button>
@@ -783,7 +783,7 @@ export default function DTRHistory() {
                 accept=".csv,.json"
                 onChange={handleFileImport}
                 disabled={importing}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-purple-500 file:text-white file:cursor-pointer hover:file:bg-purple-600 disabled:opacity-50"
+                className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-blue-500 file:text-white file:cursor-pointer hover:file:bg-blue-600 disabled:opacity-50"
               />
               <p className="text-gray-400 text-xs mt-2">
                 Supported formats: CSV (recommended), JSON. For Excel files, please convert to CSV first.
@@ -852,7 +852,7 @@ export default function DTRHistory() {
                   setImportResults(null);
                   setError('');
                 }}
-                className="px-6 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all"
+                className="px-6 py-2 bg-gradient-to-r from-blue-500 to-cyan-500 text-white rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all"
               >
                 Close
               </button>

--- a/frontend/components/DTRSystem.tsx
+++ b/frontend/components/DTRSystem.tsx
@@ -395,14 +395,14 @@ export default function DTRSystem() {
                 value={accomplishmentNote}
                 onChange={(e) => setAccomplishmentNote(e.target.value)}
                 placeholder="Describe what you accomplished today..."
-                className="w-full bg-white/5 border border-white/10 rounded-lg p-3 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                className="w-full bg-white/5 border border-white/10 rounded-lg p-3 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 rows={3}
               />
             </div>
             <button
               onClick={handleTimeOut}
               disabled={loading || !accomplishmentNote.trim()}
-              className="w-full bg-gradient-to-r from-red-500 to-pink-600 hover:from-red-600 hover:to-pink-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-300 disabled:opacity-50"
+              className="w-full bg-gradient-to-r from-red-500 to-rose-600 hover:from-red-600 hover:to-rose-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-300 disabled:opacity-50"
             >
               {loading ? 'Clocking Out...' : 'Clock Out'}
             </button>
@@ -425,7 +425,7 @@ export default function DTRSystem() {
         
         {/* Time Button */}
         <div className="mt-6 text-center">
-          <button className="bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700 text-white font-semibold py-3 px-8 rounded-lg transition-all duration-300 shadow-lg hover:shadow-xl">
+          <button className="bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700 text-white font-semibold py-3 px-8 rounded-lg transition-all duration-300 shadow-lg hover:shadow-xl">
             <div className="text-lg font-mono">
               {currentTime.toLocaleTimeString('en-US', {
                 hour: '2-digit',
@@ -465,7 +465,7 @@ export default function DTRSystem() {
                   </div>
                   <div className="text-right">
                     {entry.hoursWorked > 0 && (
-                      <div className="text-purple-400 font-semibold">
+                      <div className="text-blue-400 font-semibold">
                         {entry.hoursWorked.toFixed(1)}h
                       </div>
                     )}

--- a/frontend/components/HoursManager.tsx
+++ b/frontend/components/HoursManager.tsx
@@ -132,15 +132,15 @@ export default function HoursManager() {
   const getProgressColor = () => {
     const percentage = getProgressPercentage();
     if (percentage >= 100) return 'from-green-500 to-emerald-500';
-    if (percentage >= 75) return 'from-blue-500 to-purple-500';
+    if (percentage >= 75) return 'from-blue-500 to-cyan-500';
     if (percentage >= 50) return 'from-yellow-500 to-orange-500';
-    return 'from-red-500 to-pink-500';
+    return 'from-red-500 to-rose-500';
   };
 
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="w-12 h-12 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full animate-spin flex items-center justify-center">
+        <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full animate-spin flex items-center justify-center">
           <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full"></div>
         </div>
       </div>
@@ -158,7 +158,7 @@ export default function HoursManager() {
         {hoursData?.requiredHours && (
           <button
             onClick={() => setShowSetHours(true)}
-            className="px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors text-sm"
+            className="px-4 py-2 bg-blue-500/20 text-blue-400 rounded-lg hover:bg-blue-500/30 transition-colors text-sm"
           >
             Update Required Hours
           </button>
@@ -205,7 +205,7 @@ export default function HoursManager() {
                   <defs>
                     <linearGradient id="progressGradient" x1="0%" y1="0%" x2="100%" y2="100%">
                       <stop offset="0%" className="stop-color-current" style={{ stopColor: getProgressColor().includes('green') ? '#10b981' : getProgressColor().includes('blue') ? '#3b82f6' : getProgressColor().includes('yellow') ? '#f59e0b' : '#ef4444' }} />
-                      <stop offset="100%" className="stop-color-current" style={{ stopColor: getProgressColor().includes('green') ? '#059669' : getProgressColor().includes('blue') ? '#8b5cf6' : getProgressColor().includes('yellow') ? '#ea580c' : '#ec4899' }} />
+                      <stop offset="100%" className="stop-color-current" style={{ stopColor: getProgressColor().includes('green') ? '#059669' : getProgressColor().includes('blue') ? '#0ea5e9' : getProgressColor().includes('yellow') ? '#ea580c' : '#ef4444' }} />
                     </linearGradient>
                   </defs>
                 </svg>
@@ -257,13 +257,13 @@ export default function HoursManager() {
 
             {/* Additional Info */}
             {hoursData.requiredHours && hoursData.requiredHours > 0 && (
-              <div className="bg-purple-500/10 border border-purple-500/20 rounded-lg p-4">
+              <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4">
                 <div className="flex items-start space-x-3">
-                  <svg className="w-5 h-5 text-purple-400 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 text-blue-400 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   <div>
-                    <p className="text-purple-400 font-medium text-sm mb-1">Progress Update</p>
+                    <p className="text-blue-400 font-medium text-sm mb-1">Progress Update</p>
                     <p className="text-gray-300 text-sm">
                       {hoursData.isComplete 
                         ? "Congratulations! You have completed your required internship hours." 
@@ -315,7 +315,7 @@ export default function HoursManager() {
                 value={requiredHoursInput}
                 onChange={(e) => setRequiredHoursInput(e.target.value)}
                 placeholder="e.g. 500"
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               <p className="text-gray-400 text-xs mt-2">
                 Enter the total number of hours required to complete your internship
@@ -337,7 +337,7 @@ export default function HoursManager() {
               <button
                 onClick={handleSetRequiredHours}
                 disabled={settingHours || !requiredHoursInput}
-                className="px-6 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-6 py-2 bg-gradient-to-r from-blue-500 to-cyan-500 text-white rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {settingHours ? 'Setting...' : 'Set Hours'}
               </button>

--- a/frontend/components/NapReport.tsx
+++ b/frontend/components/NapReport.tsx
@@ -233,9 +233,9 @@ export default function NapReport() {
   const totals = calculateTotals();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 relative overflow-hidden">
       {/* Background gradient overlays */}
-      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10"></div>
+      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-blue-500/10 to-cyan-500/10"></div>
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.1),transparent_50%)]"></div>
       
       <div className="relative z-[5] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
@@ -248,7 +248,7 @@ export default function NapReport() {
         {/* Alert Messages */}
         {error && (
           <div className="mb-6 group relative">
-            <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-pink-600/20 rounded-xl blur opacity-75"></div>
+            <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-rose-600/20 rounded-xl blur opacity-75"></div>
             <div className="relative backdrop-blur-xl bg-red-500/10 border border-red-500/20 rounded-xl p-4">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-3">
@@ -300,7 +300,7 @@ export default function NapReport() {
 
         {/* Upload Section */}
         <div className="mb-6 sm:mb-8 group relative">
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
           <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-6">
             <h2 className="text-xl font-semibold text-white mb-4">Upload NAP Report</h2>
             
@@ -314,7 +314,7 @@ export default function NapReport() {
                     type="file"
                     accept=".pdf"
                     onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
-                    className="block w-full text-sm text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-purple-600 file:text-white hover:file:bg-purple-700 file:cursor-pointer cursor-pointer bg-white/5 border border-white/20 rounded-lg"
+                    className="block w-full text-sm text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700 file:cursor-pointer cursor-pointer bg-white/5 border border-white/20 rounded-lg"
                   />
                 </div>
                 {file && (
@@ -327,7 +327,7 @@ export default function NapReport() {
               <button
                 onClick={handleUpload}
                 disabled={loading || !file}
-                className="px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 text-white font-semibold rounded-lg hover:from-purple-700 hover:to-pink-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 flex items-center space-x-2"
+                className="px-6 py-3 bg-gradient-to-r from-blue-600 to-cyan-600 text-white font-semibold rounded-lg hover:from-blue-700 hover:to-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 flex items-center space-x-2"
               >
                 {loading ? (
                   <>
@@ -351,7 +351,7 @@ export default function NapReport() {
 
         {/* Reports Table */}
         <div className="group relative">
-          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-purple-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
           <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-6">
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-6 space-y-4 sm:space-y-0">
               <h2 className="text-xl font-semibold text-white">
@@ -367,7 +367,7 @@ export default function NapReport() {
                   <select
                     value={selectedMonth}
                     onChange={(e) => handleMonthFilter(e.target.value)}
-                    className="bg-white/5 border border-white/20 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="bg-white/5 border border-white/20 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <option value="">All Months</option>
                     {availableMonths.map((month) => (
@@ -398,7 +398,7 @@ export default function NapReport() {
                     <button
                       onClick={() => exportExcel('all')}
                       disabled={allReports.length === 0}
-                      className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold rounded-lg hover:from-blue-700 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 flex items-center space-x-2 text-sm"
+                    className="px-4 py-2 bg-gradient-to-r from-blue-600 to-cyan-600 text-white font-semibold rounded-lg hover:from-blue-700 hover:to-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 flex items-center space-x-2 text-sm"
                     >
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4" />
@@ -424,7 +424,7 @@ export default function NapReport() {
             {loading && !file ? (
               <div className="flex items-center justify-center py-12">
                 <div className="flex items-center space-x-3">
-                  <svg className="animate-spin w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="animate-spin w-6 h-6 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                   </svg>
                   <span className="text-gray-300">Loading reports...</span>
@@ -457,7 +457,7 @@ export default function NapReport() {
                       <tr>
                         <td colSpan={5} className="px-4 py-12 text-center">
                           <div className="text-center">
-                            <div className="w-16 h-16 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full mx-auto mb-4 flex items-center justify-center">
+                            <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full mx-auto mb-4 flex items-center justify-center">
                               <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                               </svg>

--- a/frontend/components/RecruitsManagement.tsx
+++ b/frontend/components/RecruitsManagement.tsx
@@ -835,7 +835,7 @@ export default function RecruitsManagement() {
     switch (status) {
       case 'Applied': return 'bg-blue-500/20 text-blue-400';
       case 'Pending': return 'bg-orange-500/20 text-orange-400'; // For scheduled interviews
-      case 'Pending Final Interview': return 'bg-purple-500/20 text-purple-400'; // Awaiting final interview
+      case 'Pending Final Interview': return 'bg-blue-500/20 text-blue-400'; // Awaiting final interview
       case 'Interviewed': return 'bg-yellow-500/20 text-yellow-400';
       case 'Hired': return 'bg-green-500/20 text-green-400';
       case 'Rejected': return 'bg-red-500/20 text-red-400';
@@ -959,7 +959,7 @@ export default function RecruitsManagement() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="w-12 h-12 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full animate-spin flex items-center justify-center">
+        <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full animate-spin flex items-center justify-center">
           <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full"></div>
         </div>
       </div>
@@ -982,7 +982,7 @@ export default function RecruitsManagement() {
         </div>
         <button
           onClick={() => setShowAddForm(true)}
-          className="px-4 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all flex items-center space-x-2"
+          className="px-4 py-2 bg-gradient-to-r from-blue-500 to-cyan-500 text-white rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all flex items-center space-x-2"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -1006,13 +1006,13 @@ export default function RecruitsManagement() {
             placeholder="Search by name, email, or contact number..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+            className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+          className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
           style={{
             backgroundColor: 'rgba(255, 255, 255, 0.1)',
             color: 'white'
@@ -1063,7 +1063,7 @@ export default function RecruitsManagement() {
                       <div className="text-gray-400 text-sm">{recruit.email}</div>
                       <div className="text-gray-400 text-sm">{recruit.permanentAddress}</div>
                       {recruit.source && (
-                        <div className="text-purple-400 text-xs mt-1 bg-purple-500/20 px-2 py-1 rounded-full inline-block">
+                        <div className="text-blue-400 text-xs mt-1 bg-blue-500/20 px-2 py-1 rounded-full inline-block">
                           Source: {recruit.source}
                         </div>
                       )}
@@ -1087,7 +1087,7 @@ export default function RecruitsManagement() {
                       <select
                         value={recruit.applicationStatus}
                         onChange={(e) => handleStatusUpdate(recruit._id, e.target.value)}
-                        className="text-xs bg-white/10 border border-white/20 rounded px-2 py-1 text-white focus:outline-none focus:ring-1 focus:ring-purple-500"
+                        className="text-xs bg-white/10 border border-white/20 rounded px-2 py-1 text-white focus:outline-none focus:ring-1 focus:ring-blue-500"
                       >
                         <option value="Applied" style={{ backgroundColor: '#1f2937', color: 'white' }}>Applied</option>
                         <option value="Pending" style={{ backgroundColor: '#1f2937', color: 'white' }}>Pending Interview</option>
@@ -1249,7 +1249,7 @@ export default function RecruitsManagement() {
                     required
                     value={formData.fullName}
                     onChange={(e) => setFormData({ ...formData, fullName: e.target.value })}
-                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -1262,7 +1262,7 @@ export default function RecruitsManagement() {
                     required
                     value={formData.contactNumber}
                     onChange={(e) => setFormData({ ...formData, contactNumber: e.target.value })}
-                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -1275,7 +1275,7 @@ export default function RecruitsManagement() {
                     required
                     value={formData.email}
                     onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -1287,7 +1287,7 @@ export default function RecruitsManagement() {
                     required
                     value={formData.educationalStatus}
                     onChange={(e) => setFormData({ ...formData, educationalStatus: e.target.value as any })}
-                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <option value="UNDERGRAD" style={{ backgroundColor: '#1f2937', color: 'white' }}>Undergraduate</option>
                     <option value="GRADUATE" style={{ backgroundColor: '#1f2937', color: 'white' }}>Graduate</option>
@@ -1303,7 +1303,7 @@ export default function RecruitsManagement() {
                     type="text"
                     value={formData.course}
                     onChange={(e) => setFormData({ ...formData, course: e.target.value })}
-                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -1315,7 +1315,7 @@ export default function RecruitsManagement() {
                     type="text"
                     value={formData.school}
                     onChange={(e) => setFormData({ ...formData, school: e.target.value })}
-                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -1326,7 +1326,7 @@ export default function RecruitsManagement() {
                   <select
                     value={formData.source}
                     onChange={(e) => setFormData({ ...formData, source: e.target.value })}
-                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <option value="" style={{ backgroundColor: '#1f2937', color: 'white' }}>Select Source</option>
                     <option value="Job Portal" style={{ backgroundColor: '#1f2937', color: 'white' }}>Job Portal</option>
@@ -1352,7 +1352,7 @@ export default function RecruitsManagement() {
                   value={formData.permanentAddress}
                   onChange={(e) => setFormData({ ...formData, permanentAddress: e.target.value })}
                   rows={3}
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
 
@@ -1365,7 +1365,7 @@ export default function RecruitsManagement() {
                   required
                   value={formData.dateApplied}
                   onChange={(e) => setFormData({ ...formData, dateApplied: e.target.value })}
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
 
@@ -1377,7 +1377,7 @@ export default function RecruitsManagement() {
                   type="file"
                   accept=".pdf,.doc,.docx"
                   onChange={(e) => setSelectedFile(e.target.files?.[0] || null)}
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-purple-500 file:text-white file:cursor-pointer hover:file:bg-purple-600"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-blue-500 file:text-white file:cursor-pointer hover:file:bg-blue-600"
                 />
               </div>
 
@@ -1394,7 +1394,7 @@ export default function RecruitsManagement() {
                 </button>
                 <button
                   type="submit"
-                  className="px-6 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all"
+                  className="px-6 py-2 bg-gradient-to-r from-blue-500 to-cyan-500 text-white rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all"
                 >
                   Add Recruit
                 </button>
@@ -1445,7 +1445,7 @@ export default function RecruitsManagement() {
                   required
                   value={scheduleData.interviewDate}
                   onChange={(e) => setScheduleData({ ...scheduleData, interviewDate: e.target.value })}
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
 
@@ -1458,7 +1458,7 @@ export default function RecruitsManagement() {
                   required
                   value={scheduleData.interviewTime}
                   onChange={(e) => setScheduleData({ ...scheduleData, interviewTime: e.target.value })}
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
 
@@ -1469,7 +1469,7 @@ export default function RecruitsManagement() {
                 <select
                   value={scheduleData.interviewerId}
                   onChange={(e) => setScheduleData({ ...scheduleData, interviewerId: e.target.value })}
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                   <option value="" style={{ backgroundColor: '#1f2937', color: 'white' }}>Select Interviewer</option>
                   {users
@@ -1501,7 +1501,7 @@ export default function RecruitsManagement() {
                   onChange={(e) => setScheduleData({ ...scheduleData, interviewNotes: e.target.value })}
                   rows={3}
                   placeholder="Additional notes for the interview..."
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
 
@@ -1546,7 +1546,7 @@ export default function RecruitsManagement() {
                 </button>
                 <button
                   type="submit"
-                  className="px-6 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all"
+                  className="px-6 py-2 bg-gradient-to-r from-blue-500 to-cyan-500 text-white rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all"
                 >
                   Schedule {scheduleData.interviewType === 'initial' ? 'Initial' : 'Final'} Interview
                 </button>
@@ -1590,7 +1590,7 @@ export default function RecruitsManagement() {
                 <select
                   value={selectedUnitManager}
                   onChange={(e) => setSelectedUnitManager(e.target.value)}
-                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                   required
                 >
                   <option value="" style={{ backgroundColor: '#1f2937', color: 'white' }}>Select Unit Manager</option>

--- a/frontend/components/SupervisionManager.tsx
+++ b/frontend/components/SupervisionManager.tsx
@@ -234,8 +234,8 @@ export default function SupervisionManager() {
               <p className="text-sm text-gray-400">Avg Hours/Day</p>
               <p className="text-2xl font-bold text-white">{stats.avgHoursWorked.toFixed(1)}</p>
             </div>
-            <div className="w-12 h-12 bg-purple-500/20 rounded-lg flex items-center justify-center">
-              <svg className="w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="w-12 h-12 bg-blue-500/20 rounded-lg flex items-center justify-center">
+              <svg className="w-6 h-6 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
@@ -271,7 +271,7 @@ export default function SupervisionManager() {
               placeholder="Search users..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full bg-white/5 border border-white/10 rounded-lg p-3 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              className="w-full bg-white/5 border border-white/10 rounded-lg p-3 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
 
@@ -282,7 +282,7 @@ export default function SupervisionManager() {
               filteredAvailableUsers.map((user) => (
                 <div key={user._id} className="flex items-center justify-between p-3 bg-white/5 rounded-lg hover:bg-white/10 transition-colors">
                   <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 bg-gradient-to-br from-blue-400 to-purple-500 rounded-full flex items-center justify-center">
+                    <div className="w-10 h-10 bg-gradient-to-br from-blue-400 to-cyan-500 rounded-full flex items-center justify-center">
                       <span className="text-white font-semibold text-sm">
                         {user.name.split(' ').map(n => n[0]).join('').slice(0, 2)}
                       </span>
@@ -290,7 +290,7 @@ export default function SupervisionManager() {
                     <div>
                       <p className="text-white font-medium">{user.name}</p>
                       <p className="text-gray-400 text-sm">{user.email}</p>
-                      <p className="text-xs text-purple-400 capitalize">{user.role}</p>
+                      <p className="text-xs text-blue-400 capitalize">{user.role}</p>
                     </div>
                   </div>
                   <button
@@ -329,7 +329,7 @@ export default function SupervisionManager() {
                       <p className="text-white font-medium">{user.name}</p>
                       <p className="text-gray-400 text-sm">{user.email}</p>
                       <div className="flex items-center space-x-2">
-                        <p className="text-xs text-purple-400 capitalize">{user.role}</p>
+                        <p className="text-xs text-blue-400 capitalize">{user.role}</p>
                         <span className="text-xs text-gray-500">•</span>
                         <p className="text-xs text-gray-500">Added {formatDate(user.createdAt)}</p>
                       </div>
@@ -338,7 +338,7 @@ export default function SupervisionManager() {
                   <button
                     onClick={() => removeFromSupervision(user._id)}
                     disabled={loading}
-                    className="px-4 py-2 bg-gradient-to-r from-red-500 to-pink-600 hover:from-red-600 hover:to-pink-700 text-white text-sm font-medium rounded-lg transition-all duration-300 disabled:opacity-50"
+                    className="px-4 py-2 bg-gradient-to-r from-red-500 to-rose-600 hover:from-red-600 hover:to-rose-700 text-white text-sm font-medium rounded-lg transition-all duration-300 disabled:opacity-50"
                   >
                     Remove
                   </button>

--- a/frontend/components/TeamHoursSummary.tsx
+++ b/frontend/components/TeamHoursSummary.tsx
@@ -90,13 +90,13 @@ export default function TeamHoursSummary() {
     if (member.role !== 'intern') return 'text-blue-400';
     if (!member.requiredHours || member.requiredHours === 0) return 'text-yellow-400';
     if (member.isComplete) return 'text-green-400';
-    return 'text-purple-400';
+    return 'text-blue-400';
   };
 
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="w-12 h-12 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full animate-spin flex items-center justify-center">
+        <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full animate-spin flex items-center justify-center">
           <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full"></div>
         </div>
       </div>
@@ -113,7 +113,7 @@ export default function TeamHoursSummary() {
         </div>
         <button
           onClick={fetchTeamHours}
-          className="px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors text-sm flex items-center space-x-2"
+          className="px-4 py-2 bg-blue-500/20 text-blue-400 rounded-lg hover:bg-blue-500/30 transition-colors text-sm flex items-center space-x-2"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -138,7 +138,7 @@ export default function TeamHoursSummary() {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">
                     {/* Avatar */}
-                    <div className="w-12 h-12 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full flex items-center justify-center text-white font-semibold">
+                    <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full flex items-center justify-center text-white font-semibold">
                       {member.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)}
                     </div>
                     
@@ -202,7 +202,7 @@ export default function TeamHoursSummary() {
           </div>
         ) : (
           <div className="text-center py-12">
-            <div className="w-16 h-16 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full mx-auto mb-4 flex items-center justify-center">
+            <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full mx-auto mb-4 flex items-center justify-center">
               <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
               </svg>

--- a/frontend/components/TeamReports.tsx
+++ b/frontend/components/TeamReports.tsx
@@ -99,7 +99,7 @@ export default function TeamReports() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="w-12 h-12 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full animate-spin flex items-center justify-center">
+        <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full animate-spin flex items-center justify-center">
           <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full"></div>
         </div>
       </div>
@@ -128,7 +128,7 @@ export default function TeamReports() {
               onClick={() => setSelectedPeriod(period)}
               className={`px-4 py-2 rounded-lg font-medium text-sm transition-all duration-300 ${
                 selectedPeriod === period
-                  ? 'bg-gradient-to-r from-purple-500 to-pink-600 text-white'
+                  ? 'bg-gradient-to-r from-blue-500 to-cyan-600 text-white'
                   : 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white'
               }`}
             >
@@ -204,8 +204,8 @@ export default function TeamReports() {
                   <p className="text-sm font-medium text-gray-400 mb-1">Avg Productivity</p>
                   <p className="text-2xl sm:text-3xl font-bold text-white">{reportData.avgProductivity.toFixed(1)}%</p>
                 </div>
-                <div className="w-12 h-12 bg-purple-500/20 rounded-lg flex items-center justify-center flex-shrink-0 ml-4">
-                  <svg className="w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="w-12 h-12 bg-blue-500/20 rounded-lg flex items-center justify-center flex-shrink-0 ml-4">
+                  <svg className="w-6 h-6 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
                   </svg>
                 </div>
@@ -251,7 +251,7 @@ export default function TeamReports() {
                     <tr key={member._id} className="border-b border-white/5 hover:bg-white/5 transition-colors">
                       <td className="py-4">
                         <div className="flex items-center space-x-3">
-                          <div className="w-10 h-10 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full flex items-center justify-center">
+                          <div className="w-10 h-10 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full flex items-center justify-center">
                             <span className="text-white font-semibold text-sm">
                               {member.name.split(' ').map(n => n[0]).join('').slice(0, 2)}
                             </span>
@@ -263,7 +263,7 @@ export default function TeamReports() {
                         </div>
                       </td>
                       <td className="py-4">
-                        <span className="text-purple-400 capitalize text-sm">{member.role}</span>
+                        <span className="text-blue-400 capitalize text-sm">{member.role}</span>
                       </td>
                       <td className="py-4">
                         <span className="text-white font-medium">{member.totalHours.toFixed(1)}h</span>
@@ -308,7 +308,7 @@ export default function TeamReports() {
           <div className="bg-white/5 backdrop-blur-xl rounded-xl p-4 sm:p-6 border border-white/10">
             <h3 className="text-xl font-semibold text-white mb-4 sm:mb-6">Export Reports</h3>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              <button className="flex items-center justify-center space-x-3 p-4 sm:p-5 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 rounded-lg transition-all duration-300 hover:scale-105">
+              <button className="flex items-center justify-center space-x-3 p-4 sm:p-5 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 rounded-lg transition-all duration-300 hover:scale-105">
                 <svg className="w-5 h-5 text-white flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                 </svg>

--- a/frontend/components/TeamStatus.tsx
+++ b/frontend/components/TeamStatus.tsx
@@ -174,7 +174,7 @@ export default function TeamStatus() {
         <div className="absolute inset-0 bg-gradient-to-r from-emerald-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
         <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-6">
           <div className="text-center text-gray-400 py-8">
-            <div className="animate-spin w-8 h-8 border-2 border-purple-400 border-t-transparent rounded-full mx-auto mb-4"></div>
+            <div className="animate-spin w-8 h-8 border-2 border-blue-400 border-t-transparent rounded-full mx-auto mb-4"></div>
             <p>Loading team status...</p>
           </div>
         </div>
@@ -185,7 +185,7 @@ export default function TeamStatus() {
   if (error) {
     return (
       <div className="group relative">
-        <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-pink-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+        <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-rose-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
         <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-6">
           <div className="text-center text-red-400 py-8">
             <svg className="w-12 h-12 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -236,7 +236,7 @@ export default function TeamStatus() {
                 >
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center space-x-3">
-                      <div className="w-10 h-10 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full flex items-center justify-center text-white font-semibold text-sm">
+                      <div className="w-10 h-10 bg-gradient-to-br from-blue-400 to-cyan-400 rounded-full flex items-center justify-center text-white font-semibold text-sm">
                         {member.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)}
                       </div>
                       <div>
@@ -282,12 +282,12 @@ export default function TeamStatus() {
       {/* Accomplishments Panel */}
       {selectedMember && (
         <div className="group relative">
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>
           <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-xl p-6">
             <div className="flex items-center justify-between mb-6">
               <div className="flex items-center space-x-3">
                 <h3 className="text-xl font-semibold text-white">Accomplishments</h3>
-                <div className="px-3 py-1 bg-purple-500/20 text-purple-400 rounded-full text-sm">
+                <div className="px-3 py-1 bg-blue-500/20 text-blue-400 rounded-full text-sm">
                   {selectedMember.name}
                 </div>
               </div>
@@ -309,14 +309,14 @@ export default function TeamStatus() {
                 value={selectedDate}
                 onChange={(e) => setSelectedDate(e.target.value)}
                 max={new Date().toISOString().split('T')[0]}
-                className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
 
             {/* Accomplishments List */}
             {loadingAccomplishments ? (
               <div className="text-center text-gray-400 py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-purple-400 border-t-transparent rounded-full mx-auto mb-4"></div>
+                <div className="animate-spin w-6 h-6 border-2 border-blue-400 border-t-transparent rounded-full mx-auto mb-4"></div>
                 <p>Loading accomplishments...</p>
               </div>
             ) : accomplishments.length === 0 ? (


### PR DESCRIPTION
## Summary
- swap legacy purple/pink accents for new blue/cyan tokens in components and pages
- refresh global styles and glass effects to match blue theme
- adjust red alerts away from pink gradients

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run type-check` *(fails: Cannot find type definition file for 'json5' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68995e5c5d08832b9706cd5a0fb43c85