### PR TITLE
feat: add macOS-inspired layout

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -129,3 +129,55 @@ body {
 .glow-blue {
   box-shadow: 0 0 20px rgba(37, 99, 235, 0.4);
 }
+
+/* macOS-inspired layout */
+.mac-window {
+  max-width: 1200px;
+  margin: 2rem auto;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(20px);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.mac-header {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.mac-traffic-light {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.mac-traffic-light.red {
+  background: #ff5f57;
+}
+
+.mac-traffic-light.yellow {
+  background: #ffbd2e;
+}
+
+.mac-traffic-light.green {
+  background: #27c93f;
+}
+
+.mac-traffic-light + .mac-traffic-light {
+  margin-left: 0.5rem;
+}
+
+.mac-content {
+  padding: 1rem;
+}
+
+.mac-card {
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(15px);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1.5rem;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -27,10 +27,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <div className="mac-window">
+          <div className="mac-header">
+            <span className="mac-traffic-light red" />
+            <span className="mac-traffic-light yellow" />
+            <span className="mac-traffic-light green" />
+          </div>
+          <main className="mac-content">{children}</main>
+        </div>
       </body>
     </html>
   );

--- a/frontend/components/AnalyticsDashboard.tsx
+++ b/frontend/components/AnalyticsDashboard.tsx
@@ -307,7 +307,7 @@ export default function AnalyticsDashboard() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>

--- a/frontend/components/DTRHistory.tsx
+++ b/frontend/components/DTRHistory.tsx
@@ -495,7 +495,7 @@ export default function DTRHistory() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>

--- a/frontend/components/DTRSystem.tsx
+++ b/frontend/components/DTRSystem.tsx
@@ -321,7 +321,7 @@ export default function DTRSystem() {
   });
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Error Message */}
       {error && (
         <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg">

--- a/frontend/components/HoursManager.tsx
+++ b/frontend/components/HoursManager.tsx
@@ -148,7 +148,7 @@ export default function HoursManager() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>

--- a/frontend/components/NapReport.tsx
+++ b/frontend/components/NapReport.tsx
@@ -238,7 +238,7 @@ export default function NapReport() {
       <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-blue-500/10 to-cyan-500/10"></div>
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.1),transparent_50%)]"></div>
       
-      <div className="relative z-[5] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
+      <div className="mac-card relative z-[5] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         {/* Header */}
         <div className="mb-6 sm:mb-8">
           <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">NAP Report Management</h1>

--- a/frontend/components/RecruitsManagement.tsx
+++ b/frontend/components/RecruitsManagement.tsx
@@ -967,7 +967,7 @@ export default function RecruitsManagement() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       <ZoomAuthPrompt
         open={showZoomPrompt}
         onClose={() => setShowZoomPrompt(false)}

--- a/frontend/components/SupervisionManager.tsx
+++ b/frontend/components/SupervisionManager.tsx
@@ -190,7 +190,7 @@ export default function SupervisionManager() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Error Message */}
       {error && (
         <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg">

--- a/frontend/components/TeamHoursSummary.tsx
+++ b/frontend/components/TeamHoursSummary.tsx
@@ -104,7 +104,7 @@ export default function TeamHoursSummary() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>

--- a/frontend/components/TeamReports.tsx
+++ b/frontend/components/TeamReports.tsx
@@ -107,7 +107,7 @@ export default function TeamReports() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Error Message */}
       {error && (
         <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg">

--- a/frontend/components/TeamStatus.tsx
+++ b/frontend/components/TeamStatus.tsx
@@ -206,7 +206,7 @@ export default function TeamStatus() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mac-card space-y-6">
       {/* Team Status Overview */}
       <div className="group relative">
         <div className="absolute inset-0 bg-gradient-to-r from-emerald-600/20 to-cyan-600/20 rounded-xl blur opacity-75 group-hover:opacity-100 transition-opacity"></div>

--- a/frontend/components/ZoomAuthPrompt.tsx
+++ b/frontend/components/ZoomAuthPrompt.tsx
@@ -16,7 +16,7 @@ export default function ZoomAuthPrompt({ open, onClose, onConnect, connecting }:
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
 
-      <div className="relative w-full max-w-md rounded-2xl border border-white/20 bg-white/10 backdrop-blur-xl shadow-2xl p-6 text-white">
+      <div className="mac-card relative w-full max-w-md rounded-2xl border border-white/20 bg-white/10 backdrop-blur-xl shadow-2xl p-6 text-white">
         <div className="flex items-start gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20 border border-blue-400/30">🔗</div>
           <div className="flex-1">


### PR DESCRIPTION
## Summary
- style root layout with macOS-inspired window chrome and traffic lights
- add mac-card utility and apply to major frontend components
- introduce global CSS classes for macOS look while keeping existing color palette

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next not found)
- `npm run type-check` (fails: Cannot find type definition files)


------
https://chatgpt.com/codex/tasks/task_e_689969cc2910832bacd23dc2353e01e4